### PR TITLE
Strawberry migration P0: pre-flight (SDL baseline, query corpus, tooling)

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -3,8 +3,9 @@ name: Dev workflow
 on:
 #  schedule:
 #    - cron:  '25 5 * * 0' # At 05:25 on Sunday
+  # No `branches:` filter — run tests on every PR regardless of base, so stacked
+  # PRs (base = a feature branch) aren't silently skipped (migration runbook Trap #14).
   pull_request:
-    branches: [main, deploy-test]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/docs/MIGRATION_LOG.md
+++ b/docs/MIGRATION_LOG.md
@@ -8,7 +8,7 @@
 - **Owner:** Chris B Chamberlain (chrisbc@artisan.co.nz)
 - **Migration branch:** `migrate/strawberry` (based on `deploy-test`)
 - **Started:** 2026-06-22
-- **Status:** Phase 0 — Pre-flight (in progress)
+- **Status:** Phase 0 — Pre-flight ✅ complete (2026-06-22); next: Phase 1 bootstrap
 - **Why this one first** (runbook §A1): smallest (~7 .py files), zip Lambda, no DynamoDB writes, no auth, minimal external integrations — lowest blast radius. The heavy `nzshm-model` library stays untouched.
 
 ---
@@ -62,6 +62,10 @@ Captured up front so the plan is grounded in what actually exists. Source: code 
 - **Auth:** API Gateway **API key** only (`TempApiKey-${stack_name}`), `private: true` on the POST route; GET (GraphiQL) public. **No `LEGACY_API_KEY` / `x-api-key` env chain** in this repo → runbook §4.3 trap is N/A (the auth contract here is the API-Gateway key, preserve that).
 - `provider.environment`: `REGION`, `DEPLOYMENT_STAGE`; function env `STACK_NAME`. IAM: single `cloudwatch:PutMetricData` allow.
 - **Routes to preserve:** `POST /graphql` (private), `GET /graphql`, `GET /graphql/{proxy+}`, `OPTIONS /graphql`, `GET /static/{proxy+}`.
+- **Secrets / environments (⚠️ delta from runbook §4.2):** this repo does **NOT** use the `AWS_TEST` / `AWS_PROD` GitHub Environments the runbook assumes. Instead:
+  - **Repo-level secrets:** `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` (static keys, created 2024-06), `SERVERLESS_ACCESS_KEY`, `CODECOV_TOKEN`, `SCHEDULED_GITHUB_SLACK_WEBHOOK`.
+  - **One environment, `DEPLOY_TEST`, with no environment-level secrets.** Deploy auth resolves from the repo-level static AWS keys + `SERVERLESS_ACCESS_KEY`.
+  - Implication: no OIDC role / per-env secret split to preserve. If migrating toward the runbook's posture is desired, that's a separate hardening task — out of scope for the code migration. Capture as runbook feedback (the four siblings may not share the AWS_TEST/AWS_PROD assumption).
 - CI uses **shared reusable workflows** from `GNS-Science/nshm-github-actions`:
   - `dev.yml` — tests; trigger `pull_request: branches: [main, deploy-test]` (⚠️ runbook Trap #14 — this `branches:` filter silently skips CI on stacked PRs; remove it).
   - `deploy-to-aws.yaml` — push to `deploy-test` or `main`; runs tests then deploys (Node 22 / Yarn; smoke query `query QueryRoot{about}`).
@@ -103,10 +107,10 @@ Captured up front so the plan is grounded in what actually exists. Source: code 
 
 > Full detail in the runbook. This is the repo-specific tracking list — tick as completed and append a dated note under "Log entries" for each.
 
-### Phase 0 — Pre-flight
-- [ ] Dump legacy Graphene SDL → `schema.legacy.graphql`, commit as parity target
-- [ ] Vendor a client query corpus (start from the test queries; chase real `runzi`/frontend queries) into `tests/fixtures/`
-- [ ] Confirm secrets: `gh secret list --env AWS_TEST` / `--env AWS_PROD`
+### Phase 0 — Pre-flight ✅
+- [x] Dump legacy Graphene SDL → `schema.legacy.graphql` (116 lines; tool: `nshm_model_graphql_api/tools/dump_legacy_sdl.py`), committed as parity target
+- [x] Seed a client query corpus in `tests/fixtures/corpus/` (6 queries, all validate against legacy schema) — ⚠️ still need to chase **real** `runzi`/frontend queries (see corpus README)
+- [x] Inventory secrets — found repo-level static AWS keys + `DEPLOY_TEST` env (NOT `AWS_TEST`/`AWS_PROD`); see delta note above
 
 ### Phase 1 — Bootstrap (zip Lambda)
 - [ ] Add deps: `strawberry-graphql>=0.243`, `fastapi>=0.115`, `mangum>=0.18`, `pydantic>=2`; `uv lock && uv sync`
@@ -146,5 +150,15 @@ Captured up front so the plan is grounded in what actually exists. Source: code 
 - Created branch `migrate/strawberry` off `deploy-test`.
 - Created this log; captured Phase 0 inventory and runbook deltas above.
 - **Next:** Phase 0 — dump legacy SDL + vendor query corpus.
+
+### 2026-06-22 — Phase 0 complete
+- Added `nshm_model_graphql_api/tools/dump_legacy_sdl.py`; committed `schema.legacy.graphql` (116 lines) as the parity target.
+- Seeded `tests/fixtures/corpus/` with 6 queries (smoke `{about}`, root info, get_models, source tree w/ `BranchSource` union, gmm tree w/ `gsim_args`, Relay `node` lookup). All validate against the legacy schema.
+- Inventoried secrets/environments → recorded the `AWS_TEST`/`AWS_PROD` delta (this repo uses repo-level static keys + a `DEPLOY_TEST` env).
+- Baseline test suite green: **39 passed**.
+- **Runbook feedback candidates (file against `nshm-toshi-api`):**
+  1. *New trap:* the SDL-dump import path can print dependency warnings to **stdout** (here `nzshm-model` emits `WARNING: optional 'toshi' dependencies are not installed`), polluting `schema.legacy.graphql`. Fix: redirect stdout→stderr around the schema import (see `dump_legacy_sdl.py`). Runbook's Phase 0 snippet (`print(str(schema))`) doesn't guard this.
+  2. *Phase 0 / §4.2 clarification:* secrets may **not** follow the `AWS_TEST`/`AWS_PROD` Environments pattern — Model uses repo-level static AWS keys + a single `DEPLOY_TEST` env. Runbook should not assume the OIDC/per-env split universally.
+- **Next:** Phase 1 — add `strawberry-graphql`/`fastapi`/`mangum`/`pydantic`, create `app.py` + `schema.py`, swap `serverless.yml` handler, verify boot.
 
 <!-- Append new dated entries above this line as the migration proceeds. -->

--- a/docs/MIGRATION_LOG.md
+++ b/docs/MIGRATION_LOG.md
@@ -161,4 +161,13 @@ Captured up front so the plan is grounded in what actually exists. Source: code 
   2. *Phase 0 / §4.2 clarification:* secrets may **not** follow the `AWS_TEST`/`AWS_PROD` Environments pattern — Model uses repo-level static AWS keys + a single `DEPLOY_TEST` env. Runbook should not assume the OIDC/per-env split universally.
 - **Next:** Phase 1 — add `strawberry-graphql`/`fastapi`/`mangum`/`pydantic`, create `app.py` + `schema.py`, swap `serverless.yml` handler, verify boot.
 
+### 2026-06-22 — client query survey (Phase 0 corpus hardening)
+Surveyed the five candidate client repos (weka, kororaa, runzi, toshi-hazard-store, solvis-graphql-api) for real queries against this API:
+- **weka is the only GraphQL client.** Vendored its real relay query `LogicTreePageQuery` → `tests/fixtures/corpus/weka__logic_tree_page.graphql` (covers `get_model` + both logic trees + the `BranchSource` union (both members) + `current_model_version` + `get_models` in one op). Endpoint: `…/weka-app-api/graphql` (dev points at the model API on `localhost:5000`).
+- **kororaa** targets the **solvis** fault-model schema (`KORORAA_nzshm_model … source_logic_tree { fault_system_branches }`), not this API.
+- **runzi (7), toshi-hazard-store (4), solvis-graphql-api (4)** all consume the **`nzshm-model` Python library directly** — no GraphQL calls to this API.
+- All 7 corpus queries validate against `schema.legacy.graphql`. Full survey table in `tests/fixtures/corpus/README.md`.
+- **Takeaway:** parity on `LogicTreePageQuery` ≈ parity for real external traffic. Re-survey before cutover in case new clients appear.
+- *(Tooling note: Explore subagents are sandboxed to this repo and can't read sibling repos — had to run the cross-repo search directly. zsh doesn't word-split unquoted `$vars`; use `$=var` or pass paths literally to `rg`.)*
+
 <!-- Append new dated entries above this line as the migration proceeds. -->

--- a/docs/MIGRATION_LOG.md
+++ b/docs/MIGRATION_LOG.md
@@ -1,0 +1,150 @@
+# Graphene → Strawberry Migration Log — `nshm-model-graphql-api`
+
+**This API is the pilot migration** for the Graphene 3 / Flask / serverless-wsgi → Strawberry / FastAPI / Mangum effort across the four GraphQL siblings.
+
+**Authoritative runbook:** [`../../nshm-toshi-api/docs/MIGRATION_RUNBOOK.md`](../../nshm-toshi-api/docs/MIGRATION_RUNBOOK.md)
+(reference migration: `nshm-toshi-api`, completed 2026-06). Read it first — this log only records **what is specific to this repo** and **what actually happened** here. Per the runbook's "Maintenance" rule, every surprise found here must be folded back into that runbook (one-line note or new trap), and this API MUST file at least one PR against it.
+
+- **Owner:** Chris B Chamberlain (chrisbc@artisan.co.nz)
+- **Migration branch:** `migrate/strawberry` (based on `deploy-test`)
+- **Started:** 2026-06-22
+- **Status:** Phase 0 — Pre-flight (in progress)
+- **Why this one first** (runbook §A1): smallest (~7 .py files), zip Lambda, no DynamoDB writes, no auth, minimal external integrations — lowest blast radius. The heavy `nzshm-model` library stays untouched.
+
+---
+
+## Repo-specific facts (Phase 0 inventory)
+
+Captured up front so the plan is grounded in what actually exists. Source: code exploration 2026-06-22.
+
+### Current stack
+- **Python** 3.12 (`>=3.12,<4.0`), **Node** 22, **Yarn** 4.14.1, **uv** for Python deps (poetry already dropped — `uv.lock` present).
+- **GraphQL:** `graphene>=3.3` + `graphql-server==3.0.0b7` (pinned pre-release) served via Flask + `flask-cors`.
+- **Serverless:** Framework v4, single plugin `serverless-wsgi`; `serverless-plugin-warmup` present in deps but **commented out** in `serverless.yml`.
+- **Handler:** `wsgi_handler.handler` → `nshm_model_graphql_api.nshm_model_graphql_api.app`.
+- **Service:** `nzshm22-model-graphql-api`, region `ap-southeast-2`, **memory 2048 MB**, **timeout 10 s**, runtime `python3.12`.
+
+### App / schema layout (`nshm_model_graphql_api/`)
+| File | Role |
+|---|---|
+| `nshm_model_graphql_api.py` | Flask app factory `create_app()`; registers `/graphql` `GraphQLView` (GraphiQL on); module-level `app` for WSGI |
+| `schema/__init__.py` | re-exports `schema_root` |
+| `schema/schema_root.py` | `QueryRoot` + `graphene.Schema(query=QueryRoot, mutation=None, auto_camelcase=False)` (line ~48) |
+| `schema/nshm_model_schema.py` | `NshmModel` (relay.Node); nested `source_logic_tree`, `gmm_logic_tree`; wraps `nzshm-model` |
+| `schema/nshm_model_sources_schema.py` | `SourceLogicTree` → `SourceBranchSet` → `SourceLogicTreeBranch`; union `BranchSource` = `BranchInversionSource` \| `BranchDistributedSource` |
+| `schema/nshm_model_gmms_schema.py` | `GroundMotionModelLogicTree` → `GmmBranchSet` → `GmmLogicTreeBranch` |
+
+### Schema contract to preserve
+- **Query-only**, no mutations → the runbook's `ClientIDMutation`/payload traps **do not apply**.
+- **`auto_camelcase=False`** today → new schema MUST use `StrawberryConfig(auto_camel_case=False)` (runbook Trap #2). All fields are snake_case (`get_models`, `get_model(version)`, `current_model_version`, `source_logic_tree`, `gmm_logic_tree`, `model_version`, `short_name`, `long_name`, `branch_set_short_name`, `tectonic_region_type`, `gsim_name`, `gsim_args`, `nrml_id`, `rupture_set_id`, `inversion_id`).
+- **7 Relay Node types**, each with custom `resolve_id` + `get_node`. Composite IDs by string concat with **per-type delimiters** — carry these forward exactly:
+  - `NshmModel`: `{version}`
+  - `SourceLogicTree` / `GroundMotionModelLogicTree`: `{model_version}`
+  - `SourceBranchSet` / `GmmBranchSet`: `{model_version}:{short_name}`
+  - `SourceLogicTreeBranch`: `{model_version}:{branch_set_short_name}:{tag}`
+  - `GmmLogicTreeBranch`: `{model_version}|{branch_set_short_name}|{gsim_name}|{json(gsim_args)}` (pipe-delimited)
+- **One union:** `BranchSource`. **One JSON scalar:** `gsim_args` (graphene `JSONString`).
+- **Two field descriptions only** (`about`, `version` on root) — otherwise undocumented.
+- **No `@deprecated` / `deprecation_reason` anywhere** → runbook's deprecated-field forward-port traps (#7, #8) are N/A for the pilot, but keep the grep discipline.
+
+### Data source
+- All data from the **`nzshm-model>=0.14.0`** library (no persistence layer). Entry points: `nm.all_model_versions()`, `nm.get_model_version(v)`, `nm.CURRENT_VERSION`.
+- Heavy use of `@functools.lru_cache` on module-level getters (`get_model_by_version`, `get_branch_set`, `get_logic_tree_branch`). Cache keys are strings → safe to carry over.
+- `uv` config keeps `nzshm-model` resolving to latest (`exclude-newer-package."nzshm-model" = false`).
+
+### Tests
+- `tests/` — 8 files (~660 LOC), ~22–28 assertions, **no `conftest.py`**, no snapshots, no moto/testcontainers, fully local (no AWS).
+- All use `graphene.test.Client(schema.schema_root)` (module-scoped fixture per file) → must move to a Strawberry test client.
+- Coverage surface: root info fields, `get_models`/`get_model`, nested source & gmm logic trees, and `node(id)` Relay lookups for all 7 types with inline fragments. `moto>=5.1` is in dev deps but **unused**.
+- `TESTING=1` is set by tox `[testenv]`, not via conftest.
+
+### Deploy / CI / secrets
+- **Auth:** API Gateway **API key** only (`TempApiKey-${stack_name}`), `private: true` on the POST route; GET (GraphiQL) public. **No `LEGACY_API_KEY` / `x-api-key` env chain** in this repo → runbook §4.3 trap is N/A (the auth contract here is the API-Gateway key, preserve that).
+- `provider.environment`: `REGION`, `DEPLOYMENT_STAGE`; function env `STACK_NAME`. IAM: single `cloudwatch:PutMetricData` allow.
+- **Routes to preserve:** `POST /graphql` (private), `GET /graphql`, `GET /graphql/{proxy+}`, `OPTIONS /graphql`, `GET /static/{proxy+}`.
+- CI uses **shared reusable workflows** from `GNS-Science/nshm-github-actions`:
+  - `dev.yml` — tests; trigger `pull_request: branches: [main, deploy-test]` (⚠️ runbook Trap #14 — this `branches:` filter silently skips CI on stacked PRs; remove it).
+  - `deploy-to-aws.yaml` — push to `deploy-test` or `main`; runs tests then deploys (Node 22 / Yarn; smoke query `query QueryRoot{about}`).
+  - `release.yml` — on `v*` tags; PyPI publish disabled.
+- `.yarnrc.yml` already has `nodeLinker: node-modules`, `npmMinimalAgeGate: 7d`, preapproved scopes (`nshm-*`, `nzshm-*`, `solvis-*`, `weka-*`, `toshi-*`) — matches runbook §4.6.
+- `setup.cfg` holds pytest + coverage + tox (`audit`, `py312`, `format`, `lint`, `build`); no standalone `tox.ini`.
+- `.bumpversion.cfg` syncs version across `pyproject.toml`, `package.json`, `__init__.py` (currently **0.4.2**).
+
+### Branch hygiene (done 2026-06-22, pre-migration)
+- Local `main` fast-forwarded (was 63 behind), stale `chore/50-migrate-to-serverless-v4` deleted, refs synced to origin.
+- Removed obsolete `package-lock.json` from `deploy-test` (`d9d667b`) — Yarn 4 project, `main` had already dropped it. Remaining `main`↔`deploy-test` delta is content-duplicate (squash + the same package-lock delete) and collapses on the next promote.
+- ⚠️ Dependabot reports **15 vulnerabilities** (7 high / 6 moderate / 2 low) on the default branch — review during Phase 4 deps hardening; `upgrades (#61)` may already cover some.
+
+---
+
+## Deltas from the runbook (what does / doesn't apply here)
+
+| Runbook item | Applies? | Note |
+|---|---|---|
+| `StrawberryConfig(auto_camel_case=False)` (Trap #2) | ✅ Yes | snake_case schema today |
+| FastAPI + Mangum entry, drop `serverless-wsgi` | ✅ Yes | handler → `<pkg>.app.handler` |
+| Drop poetry → uv | ☑️ Already done | `uv.lock` present |
+| Lint-config consolidation (Trap #3) | ⚠️ Watch | small tree; current ruff already `E,F,I,B,UP` |
+| Layered models / `_dispatch.py` (Traps #4–6) | ❌ No | only 7 types, static union; no `clazz_name` dispatch |
+| `ClientIDMutation` payload shape (Trap, Phase 2) | ❌ No | query-only API |
+| Deprecated field carry-forward (Traps #7–8) | ❌ N/A | none exist; keep grep discipline |
+| `LEGACY_API_KEY` chain (Trap #11, §4.3) | ❌ No | API-Gateway key only; preserve that instead |
+| `DB_READ_ONLY` (Trap #12) | ❌ No | no DB |
+| testcontainers / DynamoDB Local / Java (Trap #10) | ❌ No | tests fully local; moto already available if needed |
+| Remove `pull_request.branches:` filter (Trap #14) | ✅ Yes | present in `dev.yml` |
+| Yarn `resolutions` / local-dev plugin traps (§4.7, #16–17) | ⚠️ Low | only `serverless-wsgi` plugin (being removed); no s3rver/dynamodb-local |
+| Lambda memory halve-and-monitor (§4.4, #20) | ✅ Yes | 2048 MB → start at 1024 MB, watch CloudWatch |
+| SDL parity + query corpus replay (Phase 0/3) | ✅ Yes | no corpus today — vendor real queries from tests + clients |
+| 24h soak before promote (Phase 5) | 🔁 Optional | runbook says Model is the candidate to skip (low traffic) |
+
+---
+
+## Planned phase checklist (tailored)
+
+> Full detail in the runbook. This is the repo-specific tracking list — tick as completed and append a dated note under "Log entries" for each.
+
+### Phase 0 — Pre-flight
+- [ ] Dump legacy Graphene SDL → `schema.legacy.graphql`, commit as parity target
+- [ ] Vendor a client query corpus (start from the test queries; chase real `runzi`/frontend queries) into `tests/fixtures/`
+- [ ] Confirm secrets: `gh secret list --env AWS_TEST` / `--env AWS_PROD`
+
+### Phase 1 — Bootstrap (zip Lambda)
+- [ ] Add deps: `strawberry-graphql>=0.243`, `fastapi>=0.115`, `mangum>=0.18`, `pydantic>=2`; `uv lock && uv sync`
+- [ ] `nshm_model_graphql_api/app.py` — FastAPI + `GraphQLRouter` + `Mangum` handler
+- [ ] `nshm_model_graphql_api/schema.py` — `Schema(query=Query, config=StrawberryConfig(auto_camel_case=False))`
+- [ ] `serverless.yml` — drop `serverless-wsgi` + `custom.wsgi`; handler → `nshm_model_graphql_api.app.handler`; memory 2048 → 1024
+- [ ] Verify boot: `uv run uvicorn nshm_model_graphql_api.app:app --reload` → `{ __typename }`
+
+### Phase 2 — Schema migration (the 7 types)
+- [ ] `NshmModel` + root `Query` (`get_models`, `get_model`, `about`, `version`, `current_model_version`, `node`)
+- [ ] Source tree: `SourceLogicTree` → `SourceBranchSet` → `SourceLogicTreeBranch` + `BranchSource` union
+- [ ] GMM tree: `GroundMotionModelLogicTree` → `GmmBranchSet` → `GmmLogicTreeBranch`
+- [ ] Relay `Node` via `strawberry.relay`; preserve every composite-ID delimiter scheme above
+- [ ] `gsim_args` JSON scalar parity; `strawberry.lazy` for any forward refs
+
+### Phase 3 — Tests
+- [ ] Port `graphene.test.Client` → Strawberry test client (add `conftest.py` with a shared fixture)
+- [ ] SDL parity CI check vs `schema.legacy.graphql`
+- [ ] Query-corpus replay job
+
+### Phase 4 — Deploy / CI / deps
+- [ ] Remove `branches:` filter in `dev.yml` (Trap #14)
+- [ ] Memory sizing watch (1024 MB → adjust on CloudWatch)
+- [ ] Address Dependabot vulns; `uv sync --frozen` in CI
+- [ ] Confirm API-Gateway key auth unchanged; `/graphql` path preserved
+
+### Phase 5 — Cutover
+- [ ] Deploy to `test` stage from `deploy-test`; run corpus + smoke (`{about}`)
+- [ ] Pre-stage rollback PR; promote `deploy-test → main`; watch prod 30 min
+
+---
+
+## Log entries
+
+### 2026-06-22 — kickoff
+- Synced local branches with origin; deleted stale `chore/50-…v4`; forward-ported `package-lock.json` deletion to `deploy-test` (`d9d667b`).
+- Created branch `migrate/strawberry` off `deploy-test`.
+- Created this log; captured Phase 0 inventory and runbook deltas above.
+- **Next:** Phase 0 — dump legacy SDL + vendor query corpus.
+
+<!-- Append new dated entries above this line as the migration proceeds. -->

--- a/nshm_model_graphql_api/tools/dump_legacy_sdl.py
+++ b/nshm_model_graphql_api/tools/dump_legacy_sdl.py
@@ -1,0 +1,29 @@
+"""Dump the legacy Graphene schema SDL to stdout.
+
+Migration parity baseline (Phase 0 of the Graphene -> Strawberry migration).
+The committed `schema.legacy.graphql` produced by this is the parity target:
+anything removed from the new Strawberry SDL that is not marked `@deprecated`
+is a breaking change.
+
+Importing the schema pulls in dependencies (e.g. `nzshm-model`) that print
+warnings to stdout at import time; we redirect that to stderr so only the SDL
+lands on stdout and the output file stays valid.
+
+Usage:
+    uv run python -m nshm_model_graphql_api.tools.dump_legacy_sdl > schema.legacy.graphql
+"""
+
+import contextlib
+import sys
+
+
+def main() -> None:
+    # Keep import-time chatter off stdout so the SDL file is clean.
+    with contextlib.redirect_stdout(sys.stderr):
+        from nshm_model_graphql_api.schema import schema_root
+
+    print(str(schema_root), end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/schema.legacy.graphql
+++ b/schema.legacy.graphql
@@ -1,0 +1,117 @@
+schema {
+  query: QueryRoot
+}
+
+"""This is the entry point for all graphql query operations."""
+type QueryRoot {
+  node(
+    """The ID of the object"""
+    id: ID!
+  ): Node
+
+  """About this API """
+  about: String
+
+  """API version string"""
+  version: String
+  current_model_version: String
+  get_models: [NshmModel]
+  get_model(version: String): NshmModel
+}
+
+"""An object with an ID"""
+interface Node {
+  """The ID of the object"""
+  id: ID!
+}
+
+"""A custom Node representing an entire model."""
+type NshmModel implements Node {
+  """The ID of the object"""
+  id: ID!
+  version: String
+  title: String
+  source_logic_tree: SourceLogicTree
+  gmm_logic_tree: GroundMotionModelLogicTree
+}
+
+"""A custom Node representing the source logic tree of a given model."""
+type SourceLogicTree implements Node {
+  """The ID of the object"""
+  id: ID!
+  model_version: String
+  branch_sets: [SourceBranchSet]
+}
+
+type SourceBranchSet implements Node {
+  """The ID of the object"""
+  id: ID!
+  model_version: String
+  short_name: String
+  long_name: String
+  branches: [SourceLogicTreeBranch]
+}
+
+type SourceLogicTreeBranch implements Node {
+  """The ID of the object"""
+  id: ID!
+  model_version: String
+  branch_set_short_name: String
+  tag: String
+  weight: Float
+  sources: [BranchSource]
+}
+
+union BranchSource = BranchInversionSource | BranchDistributedSource
+
+type BranchInversionSource {
+  nrml_id: ID
+  rupture_set_id: ID
+  inversion_id: ID
+}
+
+type BranchDistributedSource {
+  nrml_id: ID
+}
+
+"""A custom Node representing the GMM logic tree of a given model."""
+type GroundMotionModelLogicTree implements Node {
+  """The ID of the object"""
+  id: ID!
+  model_version: String
+  branch_sets: [GmmBranchSet]
+}
+
+"""
+Ground Motion Model branch sets,
+
+to ensure that the wieghts of the enclosed branches sum to 1.0
+"""
+type GmmBranchSet implements Node {
+  """The ID of the object"""
+  id: ID!
+  model_version: String
+  short_name: String
+  long_name: String
+  tectonic_region_type: String
+  branches: [GmmLogicTreeBranch]
+}
+
+type GmmLogicTreeBranch implements Node {
+  """The ID of the object"""
+  id: ID!
+  model_version: String
+  branch_set_short_name: String
+  gsim_name: String
+  gsim_args: JSONString
+  tectonic_region_type: String
+  weight: Float
+}
+
+"""
+Allows use of a JSON String for input / output from the GraphQL schema.
+
+Use of this type is *not recommended* as you lose the benefits of having a defined, static
+schema (one of the key benefits of GraphQL).
+"""
+scalar JSONString

--- a/tests/fixtures/corpus/README.md
+++ b/tests/fixtures/corpus/README.md
@@ -1,0 +1,25 @@
+# Client query corpus — migration parity
+
+Real-world GraphQL queries replayed against a deployed stage to catch **runtime**
+regressions that SDL parity (`schema.legacy.graphql`) misses (runbook Phase 0
+step 2 / Phase 3 step 7).
+
+## Status: SEED ONLY
+
+These queries are **derived from the test suite and the deploy smoke query**, not
+yet from real production clients. Per the runbook (Trap #1: "New SDL passes parity
+check, prod query still breaks"), this corpus must be expanded with **real**
+queries from:
+
+- `runzi`
+- the web frontends (kororaa / NSHM site)
+- any internal scripts using this API
+
+Each file is one query, named `<client>__<purpose>.graphql`. The leading comment
+records the calling component. Vendor real query *text* (do not live-fetch at test
+time — that introduced a deploy-time dependency in toshi-api, PR #325).
+
+## How it's replayed
+
+A CI job (added in Phase 3) executes each `*.graphql` here against the test-stage
+deploy and asserts the response shape matches legacy (modulo `@deprecated` notices).

--- a/tests/fixtures/corpus/README.md
+++ b/tests/fixtures/corpus/README.md
@@ -4,20 +4,32 @@ Real-world GraphQL queries replayed against a deployed stage to catch **runtime*
 regressions that SDL parity (`schema.legacy.graphql`) misses (runbook Phase 0
 step 2 / Phase 3 step 7).
 
-## Status: SEED ONLY
+## Status
 
-These queries are **derived from the test suite and the deploy smoke query**, not
-yet from real production clients. Per the runbook (Trap #1: "New SDL passes parity
-check, prod query still breaks"), this corpus must be expanded with **real**
-queries from:
-
-- `runzi`
-- the web frontends (kororaa / NSHM site)
-- any internal scripts using this API
+- **`weka__*.graphql`** — REAL production query, vendored from the weka UI relay
+  artifacts (the only confirmed GraphQL client of this API).
+- **`seed__*.graphql` / `smoke__*.graphql`** — derived from the test suite + the
+  deploy smoke query; supplementary coverage.
 
 Each file is one query, named `<client>__<purpose>.graphql`. The leading comment
 records the calling component. Vendor real query *text* (do not live-fetch at test
 time — that introduced a deploy-time dependency in toshi-api, PR #325).
+
+## Client survey (2026-06-22)
+
+Surveyed the five candidate client repos for queries against this model API:
+
+| Repo | Verdict |
+|---|---|
+| `UI/weka` | ✅ **Client** — `LogicTreePageQuery` (`src/views/LogicTree/LogicTreePage.tsx`). Vendored as `weka__logic_tree_page.graphql`. The only real GraphQL consumer found. |
+| `UI/kororaa` | ❌ Not this API — its `FaultModelControlsQuery` targets the **solvis** fault-model schema (`KORORAA_nzshm_model … source_logic_tree { fault_system_branches }`). |
+| `MISC/nzshm-runzi` | ❌ Uses the **`nzshm-model` Python library directly** (7 import sites, e.g. `runzi/tasks/oq_hazard/*`). No GraphQL calls to this API. |
+| `LIB/toshi-hazard-store` | ❌ Uses the **`nzshm-model` library directly** (4 import sites). |
+| `API/solvis-graphql-api` | ❌ Uses the **`nzshm-model` library directly** (4 import sites); defines its own GraphQL schema. Not a client of this API. |
+
+**Implication:** weka is effectively the sole external GraphQL client. `LogicTreePageQuery`
+covers nearly the whole schema in one operation, so parity on it ≈ parity for real
+traffic. Still worth a periodic re-survey before cutover in case new clients appear.
 
 ## How it's replayed
 

--- a/tests/fixtures/corpus/seed__get_models.graphql
+++ b/tests/fixtures/corpus/seed__get_models.graphql
@@ -1,0 +1,8 @@
+# client: seed (from tests/test_schema_models.py) — list all models
+query GetModels {
+  get_models {
+    id
+    version
+    title
+  }
+}

--- a/tests/fixtures/corpus/seed__model_gmm_logic_tree.graphql
+++ b/tests/fixtures/corpus/seed__model_gmm_logic_tree.graphql
@@ -1,0 +1,26 @@
+# client: seed (from tests/test_schema_model_gmm_logic_tree.py)
+# full GMM logic tree, including the gsim_args JSON scalar
+query ModelGmmLogicTree {
+  get_model(version: "NSHM_v1.0.4") {
+    id
+    version
+    gmm_logic_tree {
+      id
+      model_version
+      branch_sets {
+        id
+        short_name
+        long_name
+        tectonic_region_type
+        branches {
+          model_version
+          branch_set_short_name
+          gsim_name
+          gsim_args
+          tectonic_region_type
+          weight
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/corpus/seed__model_source_logic_tree.graphql
+++ b/tests/fixtures/corpus/seed__model_source_logic_tree.graphql
@@ -1,0 +1,36 @@
+# client: seed (from tests/test_schema_model_source_logic_tree.py)
+# full source logic tree, including the BranchSource union
+query ModelSourceLogicTree {
+  get_model(version: "NSHM_v1.0.4") {
+    id
+    version
+    title
+    source_logic_tree {
+      id
+      model_version
+      branch_sets {
+        id
+        short_name
+        long_name
+        branches {
+          __typename
+          model_version
+          branch_set_short_name
+          tag
+          weight
+          sources {
+            __typename
+            ... on BranchInversionSource {
+              nrml_id
+              rupture_set_id
+              inversion_id
+            }
+            ... on BranchDistributedSource {
+              nrml_id
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/corpus/seed__node_relay_lookup.graphql
+++ b/tests/fixtures/corpus/seed__node_relay_lookup.graphql
@@ -1,0 +1,44 @@
+# client: seed (from tests/test_schema_*_as_relay_node.py)
+# Relay global-ID lookup via the Node interface. The `id` value is a
+# base64 global id (e.g. to_global_id("NshmModel", "NSHM_v1.0.4")); replace
+# at replay time. Exercises inline fragments across the Node-implementing types.
+query NodeLookup($id: ID!) {
+  node(id: $id) {
+    id
+    __typename
+    ... on NshmModel {
+      version
+      title
+    }
+    ... on SourceLogicTree {
+      model_version
+    }
+    ... on SourceBranchSet {
+      model_version
+      short_name
+      long_name
+    }
+    ... on SourceLogicTreeBranch {
+      model_version
+      branch_set_short_name
+      tag
+      weight
+    }
+    ... on GroundMotionModelLogicTree {
+      model_version
+    }
+    ... on GmmBranchSet {
+      model_version
+      short_name
+      long_name
+      tectonic_region_type
+    }
+    ... on GmmLogicTreeBranch {
+      model_version
+      branch_set_short_name
+      gsim_name
+      gsim_args
+      weight
+    }
+  }
+}

--- a/tests/fixtures/corpus/seed__root_info.graphql
+++ b/tests/fixtures/corpus/seed__root_info.graphql
@@ -1,0 +1,6 @@
+# client: seed (from tests/test_schema_info.py) — root info fields
+query RootInfo {
+  about
+  version
+  current_model_version
+}

--- a/tests/fixtures/corpus/smoke__about.graphql
+++ b/tests/fixtures/corpus/smoke__about.graphql
@@ -1,0 +1,4 @@
+# client: deploy-to-aws.yaml smoke test (post-deploy health check)
+query QueryRoot {
+  about
+}

--- a/tests/fixtures/corpus/weka__logic_tree_page.graphql
+++ b/tests/fixtures/corpus/weka__logic_tree_page.graphql
@@ -1,0 +1,58 @@
+# client: weka UI — src/views/LogicTree/LogicTreePage.tsx (relay LogicTreePageQuery)
+# REAL production query (relay-compiled text). The single page query that drives
+# the Logic Tree view; the Source/GMM tabs consume its result via props.
+# Exercises nearly the whole schema in one operation: get_model, both logic
+# trees, the BranchSource union (both members), current_model_version, get_models.
+query LogicTreePageQuery($version: String!) {
+  get_model(version: $version) {
+    id
+    version
+    title
+    gmm_logic_tree {
+      id
+      branch_sets {
+        model_version
+        short_name
+        long_name
+        tectonic_region_type
+        branches {
+          gsim_name
+          gsim_args
+          weight
+          id
+        }
+        id
+      }
+    }
+    source_logic_tree {
+      id
+      branch_sets {
+        id
+        short_name
+        long_name
+        branches {
+          tag
+          weight
+          sources {
+            __typename
+            ... on BranchInversionSource {
+              nrml_id
+              inversion_id
+              rupture_set_id
+            }
+            ... on BranchDistributedSource {
+              nrml_id
+            }
+          }
+          id
+        }
+      }
+    }
+  }
+  current_model_version
+  get_models {
+    id
+    version
+    title
+  }
+}


### PR DESCRIPTION
**Stacked PR 1 of 3** — Graphene → Strawberry migration (pilot). Base: \`deploy-test\`.

Phase 0 establishes the parity safety net **before any code changes**:
- \`schema.legacy.graphql\` — the Graphene SDL baseline (parity target), via new \`tools/dump_legacy_sdl.py\`
- \`tests/fixtures/corpus/\` — client query corpus, incl. the **real weka \`LogicTreePageQuery\`** (weka is the only GraphQL client; runzi/toshi-hazard-store/solvis use the \`nzshm-model\` library directly; kororaa hits solvis)
- \`docs/MIGRATION_LOG.md\` — repo-specific log referencing the toshi-api runbook + Phase 0 inventory & deltas

No application code changes. 39 legacy tests still pass.

Stacked: **P0 → P1 (bootstrap) → P2 (schema)**. Review/merge bottom-up.