### PR TITLE
Strawberry migration P1: FastAPI/Mangum/Strawberry bootstrap

### DIFF
--- a/docs/MIGRATION_LOG.md
+++ b/docs/MIGRATION_LOG.md
@@ -8,7 +8,7 @@
 - **Owner:** Chris B Chamberlain (chrisbc@artisan.co.nz)
 - **Migration branch:** `migrate/strawberry` (based on `deploy-test`)
 - **Started:** 2026-06-22
-- **Status:** Phase 0 — Pre-flight ✅ complete (2026-06-22); next: Phase 1 bootstrap
+- **Status:** Phase 1 — Bootstrap ✅ complete (2026-06-22); next: Phase 2 schema migration
 - **Why this one first** (runbook §A1): smallest (~7 .py files), zip Lambda, no DynamoDB writes, no auth, minimal external integrations — lowest blast radius. The heavy `nzshm-model` library stays untouched.
 
 ---
@@ -112,12 +112,12 @@ Captured up front so the plan is grounded in what actually exists. Source: code 
 - [x] Seed a client query corpus in `tests/fixtures/corpus/` (6 queries, all validate against legacy schema) — ⚠️ still need to chase **real** `runzi`/frontend queries (see corpus README)
 - [x] Inventory secrets — found repo-level static AWS keys + `DEPLOY_TEST` env (NOT `AWS_TEST`/`AWS_PROD`); see delta note above
 
-### Phase 1 — Bootstrap (zip Lambda)
-- [ ] Add deps: `strawberry-graphql>=0.243`, `fastapi>=0.115`, `mangum>=0.18`, `pydantic>=2`; `uv lock && uv sync`
-- [ ] `nshm_model_graphql_api/app.py` — FastAPI + `GraphQLRouter` + `Mangum` handler
-- [ ] `nshm_model_graphql_api/schema.py` — `Schema(query=Query, config=StrawberryConfig(auto_camel_case=False))`
-- [ ] `serverless.yml` — drop `serverless-wsgi` + `custom.wsgi`; handler → `nshm_model_graphql_api.app.handler`; memory 2048 → 1024
-- [ ] Verify boot: `uv run uvicorn nshm_model_graphql_api.app:app --reload` → `{ __typename }`
+### Phase 1 — Bootstrap (zip Lambda) ✅
+- [x] Add deps: `strawberry-graphql` (0.316), `fastapi` (0.137), `mangum` (0.21), `pydantic`, `httpx` (dev); `uv lock && uv sync` (frozen-consistent)
+- [x] `nshm_model_graphql_api/app.py` — FastAPI + `GraphQLRouter` (prefix `/graphql`) + `Mangum` handler
+- [x] `nshm_model_graphql_api/strawberry_schema.py` — `Schema(query=Query, config=StrawberryConfig(auto_camel_case=False))` ⚠️ named `strawberry_schema.py` not `schema.py` (legacy `schema/` **package** still occupies that name; rename at cutover). **Minimal Query only** (scalar root fields) — full type tree is Phase 2.
+- [x] `serverless.yml` — `plugins: []` (dropped `serverless-wsgi`); removed `custom.wsgi`; handler → `nshm_model_graphql_api.app.handler`; memory 2048 → 1024
+- [x] Verify boot: HTTP `TestClient` POST `/graphql` → 200 + correct data; GET `/graphql` → GraphiQL. SDL snake_case confirmed (`current_model_version`, not camelCase). ruff/mypy clean; 39 tests still pass.
 
 ### Phase 2 — Schema migration (the 7 types)
 - [ ] `NshmModel` + root `Query` (`get_models`, `get_model`, `about`, `version`, `current_model_version`, `node`)
@@ -169,5 +169,16 @@ Surveyed the five candidate client repos (weka, kororaa, runzi, toshi-hazard-sto
 - All 7 corpus queries validate against `schema.legacy.graphql`. Full survey table in `tests/fixtures/corpus/README.md`.
 - **Takeaway:** parity on `LogicTreePageQuery` ≈ parity for real external traffic. Re-survey before cutover in case new clients appear.
 - *(Tooling note: Explore subagents are sandboxed to this repo and can't read sibling repos — had to run the cross-repo search directly. zsh doesn't word-split unquoted `$vars`; use `$=var` or pass paths literally to `rg`.)*
+
+### 2026-06-22 — Phase 1 complete
+- Added the Strawberry/FastAPI/Mangum stack to `pyproject.toml` deps (kept legacy Graphene/Flask deps alongside — removed at cutover). `uv.lock` regenerated; `uv sync --frozen` passes.
+- New scaffold: `app.py` (FastAPI + Mangum, `/graphql` preserved) and `strawberry_schema.py` (minimal Query, `auto_camel_case=False`). Legacy Flask/Graphene app untouched and still passing.
+- `serverless.yml`: removed `serverless-wsgi` plugin + `custom.wsgi`, handler → Mangum, memory 2048→1024.
+- Verified end-to-end via FastAPI `TestClient`: POST `/graphql` 200 w/ correct data, GET `/graphql` serves GraphiQL.
+- **Decisions / surprises:**
+  1. Could **not** use `schema.py` (runbook's target name) — the legacy Graphene code lives in a `schema/` **package** that occupies that import path. Used `strawberry_schema.py` during transition; rename to `schema.py` at cutover once `schema/` is deleted. *(Runbook feedback: the `<pkg>/schema.py` instruction assumes the legacy schema isn't already a package named `schema`.)*
+  2. Strawberry defaults output fields from `-> str` to **non-null** (`String!`); legacy graphene `String` is **nullable**. Annotated scalar resolvers `-> str | None` to match legacy SDL exactly (don't tighten the contract mid-migration). Watch this for every Phase 2 field.
+  3. **Deploy packaging open question (Phase 4):** with `serverless-wsgi` gone, confirmed nothing yet validates how Python deps land in the Lambda zip (no `serverless-python-requirements` in `plugins`; `package.json` has `serverless requirements` scripts; SF v4 may package natively). Flagged inline in `serverless.yml`. Not blocking — branch isn't deployed until Phase 5.
+- **Next:** Phase 2 — port the 7 types (`NshmModel`, source tree + `BranchSource` union, gmm tree) and the Relay `Node` interface into `strawberry_schema.py` / a `models/` layout, preserving the per-type composite-ID delimiter schemes and the `gsim_args` JSON scalar.
 
 <!-- Append new dated entries above this line as the migration proceeds. -->

--- a/nshm_model_graphql_api/app.py
+++ b/nshm_model_graphql_api/app.py
@@ -1,0 +1,23 @@
+"""FastAPI + Mangum entry point (migration target).
+
+Replaces the legacy Flask app (`nshm_model_graphql_api.py`) + serverless-wsgi.
+The Lambda handler is `nshm_model_graphql_api.app.handler` (Mangum), wired in
+`serverless.yml`.
+
+The `/graphql` path is preserved — clients are hardcoded to it (runbook
+"API Gateway URL" note).
+"""
+
+from fastapi import FastAPI
+from mangum import Mangum
+from strawberry.fastapi import GraphQLRouter
+
+from nshm_model_graphql_api.strawberry_schema import schema
+
+app = FastAPI(title="nshm-model-graphql-api")
+
+graphql_app: GraphQLRouter = GraphQLRouter(schema)
+app.include_router(graphql_app, prefix="/graphql")
+
+# AWS Lambda entry point.
+handler = Mangum(app)

--- a/nshm_model_graphql_api/strawberry_schema.py
+++ b/nshm_model_graphql_api/strawberry_schema.py
@@ -1,0 +1,47 @@
+"""Strawberry GraphQL schema (migration target).
+
+Phase 1 bootstrap: this currently exposes only the scalar root fields so the
+FastAPI/Mangum scaffold can boot and be smoke-tested. Phase 2 ports the full
+type tree (NshmModel, source/gmm logic trees, the BranchSource union) and the
+Relay Node interface from the legacy Graphene schema in `schema/`.
+
+`auto_camel_case=False` is mandatory — the legacy schema uses snake_case field
+names and every existing client depends on them (runbook Trap #2).
+
+Once the legacy `schema/` package is removed at cutover, this module can be
+renamed to `schema.py` to match the runbook's target layout.
+"""
+
+import strawberry
+from strawberry.schema.config import StrawberryConfig
+
+from nshm_model_graphql_api import __version__
+
+# Reused from the legacy schema for behavioural parity; will move into the
+# Strawberry type tree in Phase 2.
+from nshm_model_graphql_api.schema.nshm_model_schema import get_current_model_version
+
+
+@strawberry.type
+class Query:
+    """This is the entry point for all graphql query operations."""
+
+    # Return types are Optional to match the legacy Graphene SDL exactly
+    # (graphene String is nullable). Don't tighten the contract mid-migration.
+    @strawberry.field(description="About this API ")
+    def about(self) -> str | None:
+        return f"Hello, I am nshm_model_graphql_api, version: {__version__}!"
+
+    @strawberry.field(description="API version string")
+    def version(self) -> str | None:
+        return __version__
+
+    @strawberry.field
+    def current_model_version(self) -> str | None:
+        return get_current_model_version()
+
+
+schema = strawberry.Schema(
+    query=Query,
+    config=StrawberryConfig(auto_camel_case=False),
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,17 @@ license = {text = "AGPL-3.0-or-later"}
 
 dependencies = [
     "boto3>=1.24.57",
+    # --- Strawberry/FastAPI/Mangum stack (migration target) ---
+    "strawberry-graphql>=0.243",
+    "fastapi>=0.115",
+    "mangum>=0.18",
+    "pydantic>=2.0",
+    # --- legacy Graphene/Flask stack (removed at cutover, Phase 5) ---
     "flask>=3.0.3",
     "flask-cors>=6.0",
     "graphene>=3.3",
     "graphql-server==3.0.0b7",
+    # --- data layer / shared ---
     "python-dateutil>=2.8.2",
     "pyyaml>=6.0.1",
     "nzshm-model>=0.14.0",
@@ -24,6 +31,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "bump2version",
+    "httpx>=0.27",
     "moto>=5.1",
     "mypy",
     "pip-audit",

--- a/serverless.yml
+++ b/serverless.yml
@@ -5,8 +5,11 @@ app: nshm-model-graphql-api
 service: nzshm22-model-graphql-api
 configValidationMode: error
 
-plugins:
-  - serverless-wsgi
+plugins: []
+# serverless-wsgi removed (Strawberry/FastAPI migration). The Lambda handler is
+# now Mangum (nshm_model_graphql_api.app.handler). NOTE (Phase 4): validate how
+# Python deps get packaged into the zip without serverless-wsgi — see the
+# `serverless requirements` scripts in package.json / SF v4 native packaging.
 
 package:
   individually: false
@@ -27,12 +30,6 @@ package:
     - nshm_model_graphql_api/**
 
 custom:
-  #serverless-wsgi settings
-  wsgi:
-    app: nshm_model_graphql_api.nshm_model_graphql_api.app
-    packRequirements: false
-    pythonBin: python3
-
   #serverless-python-requirements settings
   pythonRequirements:
     dockerizePip: True
@@ -107,8 +104,8 @@ provider:
 functions:
   app:
     description: The graphql API of ${self:service}
-    handler: wsgi_handler.handler
-    memorySize: 2048 # optional, in MB, default is 1024
+    handler: nshm_model_graphql_api.app.handler
+    memorySize: 1024 # halved from legacy 2048 (runbook §4.4); monitor CloudWatch before further change
     timeout: 10 # optional, in seconds, default is 6
     events:
       - http:

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.12, <4.0"
 
 [options]
-exclude-newer = "2026-04-17T05:02:40.510642064Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
@@ -388,6 +388,18 @@ wheels = [
 ]
 
 [[package]]
+name = "cross-web"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4a/a0/bdb8370215987cc5bde497cb8b976b17ab14841566ecef2aab6ae3e6c7b0/cross_web-0.7.0.tar.gz", hash = "sha256:15fbc8b9a824a055db8127fd6e43e0773074f620fdecb6b2b587d3d0a2bdd459", size = 332407, upload-time = "2026-05-19T14:18:48.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/4a/78b52ec2edcbd9b123638f4e0421fd8699ebe653ebf63ac5f82abd2665bc/cross_web-0.7.0-py3-none-any.whl", hash = "sha256:ddea9be3c68b48eaf16561847a5831a559786949c544b3701432e00a4e8d19d9", size = 25207, upload-time = "2026-05-19T14:18:47.614Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "46.0.7"
 source = { registry = "https://pypi.org/simple" }
@@ -493,6 +505,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/29/ee/96c65e17222b973f0d3d0aa9bad6a59104ca1b0eb5b659c25c2900fccd85/dparse-0.6.4.tar.gz", hash = "sha256:90b29c39e3edc36c6284c82c4132648eaf28a01863eb3c231c2512196132201a", size = 27912, upload-time = "2024-11-08T16:52:06.444Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/26/035d1c308882514a1e6ddca27f9d3e570d67a0e293e7b4d910a70c8fe32b/dparse-0.6.4-py3-none-any.whl", hash = "sha256:fbab4d50d54d0e739fbb4dedfc3d92771003a5b9aa8545ca7a7045e3b174af57", size = 11925, upload-time = "2024-11-08T16:52:03.844Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.137.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/fe/fb25c287ff7e0f79fc6acf2e8b812725dad28d2a1446c0410bab1422ac90/fastapi-0.137.0.tar.gz", hash = "sha256:d0565d551f65a803ecff245390840867186f456ef98971f750724eed16e1541c", size = 408023, upload-time = "2026-06-14T12:51:30.672Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/f1/b38481428e50131e5345b535414d11d196f14990122fe69c9020c64e5683/fastapi-0.137.0-py3-none-any.whl", hash = "sha256:6dcbde8d464f92117c1accb9e42720f8e423fa9b86cb563b1f5862f785a06498", size = 121777, upload-time = "2026-06-14T12:51:29.067Z" },
 ]
 
 [[package]]
@@ -836,6 +864,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mangum"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/cb/d9f4d685a0b8eceac10991e15ac471d9568e4e42c2489ae9bf072828c1c2/mangum-0.21.0.tar.gz", hash = "sha256:e31ed72d67f9958fa4379f65df77729906dec6dfa00afa6ed4e06c77833000de", size = 89130, upload-time = "2026-02-01T17:17:42.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/50/e3c694b8e122551e4557450219283771334dee2ed5734a8398c8b8018c50/mangum-0.21.0-py3-none-any.whl", hash = "sha256:309e48f5c629542516c5106ecf079f4ec08809ed50df882238d98fe1392820c7", size = 17146, upload-time = "2026-02-01T17:17:41.553Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1070,22 +1110,27 @@ wheels = [
 
 [[package]]
 name = "nshm-model-graphql-api"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
+    { name = "fastapi" },
     { name = "flask" },
     { name = "flask-cors" },
     { name = "graphene" },
     { name = "graphql-server" },
+    { name = "mangum" },
     { name = "nzshm-model" },
+    { name = "pydantic" },
     { name = "python-dateutil" },
     { name = "pyyaml" },
+    { name = "strawberry-graphql" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "bump2version" },
+    { name = "httpx" },
     { name = "moto" },
     { name = "mypy" },
     { name = "pip-audit" },
@@ -1104,18 +1149,23 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "boto3", specifier = ">=1.24.57" },
+    { name = "fastapi", specifier = ">=0.115" },
     { name = "flask", specifier = ">=3.0.3" },
     { name = "flask-cors", specifier = ">=6.0" },
     { name = "graphene", specifier = ">=3.3" },
     { name = "graphql-server", specifier = "==3.0.0b7" },
+    { name = "mangum", specifier = ">=0.18" },
     { name = "nzshm-model", specifier = ">=0.14.0" },
+    { name = "pydantic", specifier = ">=2.0" },
     { name = "python-dateutil", specifier = ">=2.8.2" },
     { name = "pyyaml", specifier = ">=6.0.1" },
+    { name = "strawberry-graphql", specifier = ">=0.243" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "bump2version" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "moto", specifier = ">=5.1" },
     { name = "mypy" },
     { name = "pip-audit" },
@@ -1769,6 +1819,35 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "strawberry-graphql"
+version = "0.316.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cross-web" },
+    { name = "graphql-core" },
+    { name = "packaging" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/09/f189fd3c70544322eeba0398ccaa980d17857894c0a66d447aa0b5704686/strawberry_graphql-0.316.0.tar.gz", hash = "sha256:bee5ce0e20d522325bd1ed2db186c812c03c2ea7db29f997b35e7d694649820c", size = 223985, upload-time = "2026-05-19T17:06:10.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/dd/b2cf54803cbd0d37e3ce73c7274bdb144ba83743bc83351b5790eb2a5fad/strawberry_graphql-0.316.0-py3-none-any.whl", hash = "sha256:222e16fbbf953f5a1fa75f62bf9a8e95f274180f928f70bec459b566053aa2cb", size = 326530, upload-time = "2026-05-19T17:06:07.844Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Stacked PR 2 of 3** — Base: \`migrate/strawberry-p0-preflight\`.

Phase 1 stands up the new runtime scaffold alongside the untouched legacy app:
- deps: \`strawberry-graphql\`, \`fastapi\`, \`mangum\`, \`pydantic\` (+ \`httpx\` dev); legacy graphene/flask kept until cutover
- \`app.py\` (FastAPI + Mangum, \`/graphql\` preserved) + \`strawberry_schema.py\` (**minimal** Query, \`auto_camel_case=False\`)
- \`serverless.yml\`: drop \`serverless-wsgi\` + \`custom.wsgi\`, handler → Mangum, memory 2048→1024

Verified: POST/GET \`/graphql\` over HTTP TestClient; ruff/mypy clean; 39 legacy tests pass. Full type tree comes in P2.

⚠️ Do not deploy this branch — schema is partial until P2.