### PR TITLE
Strawberry migration P3: test infrastructure (parity + corpus + HTTP)

### DIFF
--- a/docs/MIGRATION_LOG.md
+++ b/docs/MIGRATION_LOG.md
@@ -8,7 +8,8 @@
 - **Owner:** Chris B Chamberlain (chrisbc@artisan.co.nz)
 - **Migration branch:** `migrate/strawberry` (based on `deploy-test`)
 - **Started:** 2026-06-22
-- **Status:** Phase 2 — Schema migration ✅ complete (2026-06-22); next: Phase 3 test infrastructure
+- **Status:** Phase 3 — Test infrastructure ✅ complete (2026-06-23); next: Phase 4 deploy/CI/deps hardening
+- **PRs:** stacked, one per phase — #63 (P0), #64 (P1), #65 (P2), #66 (P3). Base chain: `deploy-test` ← P0 ← P1 ← P2 ← P3.
 - **Why this one first** (runbook §A1): smallest (~7 .py files), zip Lambda, no DynamoDB writes, no auth, minimal external integrations — lowest blast radius. The heavy `nzshm-model` library stays untouched.
 
 ---
@@ -95,7 +96,7 @@ Captured up front so the plan is grounded in what actually exists. Source: code 
 | `LEGACY_API_KEY` chain (Trap #11, §4.3) | ❌ No | API-Gateway key only; preserve that instead |
 | `DB_READ_ONLY` (Trap #12) | ❌ No | no DB |
 | testcontainers / DynamoDB Local / Java (Trap #10) | ❌ No | tests fully local; moto already available if needed |
-| Remove `pull_request.branches:` filter (Trap #14) | ✅ Yes | present in `dev.yml` |
+| Remove `pull_request.branches:` filter (Trap #14) | ✅ Done | removed in P0 branch — stacked PRs were getting no CI until then |
 | Yarn `resolutions` / local-dev plugin traps (§4.7, #16–17) | ⚠️ Low | only `serverless-wsgi` plugin (being removed); no s3rver/dynamodb-local |
 | Lambda memory halve-and-monitor (§4.4, #20) | ✅ Yes | 2048 MB → start at 1024 MB, watch CloudWatch |
 | SDL parity + query corpus replay (Phase 0/3) | ✅ Yes | no corpus today — vendor real queries from tests + clients |
@@ -128,10 +129,13 @@ Captured up front so the plan is grounded in what actually exists. Source: code 
 - [x] `gsim_args` `JSONString` scalar parity (custom strawberry scalar, json.dumps/loads, exact description)
 - [x] **SDL parity ✅ + runtime parity ✅** vs legacy (see below); ruff/mypy clean; 39 legacy tests still pass
 
-### Phase 3 — Tests
-- [ ] Port `graphene.test.Client` → Strawberry test client (add `conftest.py` with a shared fixture)
-- [ ] SDL parity CI check vs `schema.legacy.graphql`
-- [ ] Query-corpus replay job
+### Phase 3 — Tests ✅
+- [x] `tests/conftest.py` — **parametrized `client` fixture** (legacy Graphene + Strawberry) with a `.execute()` shim; the 7 existing schema-test files now run against **both** schemas (their local fixtures removed)
+- [x] `tests/test_schema_parity.py` — SDL parity gate (strawberry vs committed baseline AND vs live legacy)
+- [x] `tests/test_corpus_replay.py` — every vendored corpus query executes on Strawberry with no errors
+- [x] `tests/test_strawberry_http.py` — FastAPI `TestClient` happy-path + GraphiQL + weka query over HTTP
+- [x] testcontainers **not needed** (read-only, fully local) — runbook Trap #10 N/A here
+- [x] Parity + corpus run inside `pytest`, so they're already in CI (shared `python-run-tests-uv` workflow); **87 tests pass**
 
 ### Phase 4 — Deploy / CI / deps
 - [ ] Remove `branches:` filter in `dev.yml` (Trap #14)
@@ -216,5 +220,12 @@ Ported all 7 types + union + JSONString scalar + root query to Strawberry, at st
   4. Custom scalar (`JSONString`) trips mypy `valid-type`; one `# type: ignore[valid-type]`. Global-id args typed `str | None` → coerce via f-string (matches graphql_relay's own f-string coercion) to satisfy mypy without changing output.
   5. Added `graphql-relay>=3.2` as an explicit dep (was transitive via graphene) so id encoding survives graphene removal at cutover.
 - **Next:** Phase 3 — port the test suite to the Strawberry schema (currently tests target legacy `schema_root`), wire `tools/schema_parity.py` + corpus replay into CI.
+
+### 2026-06-23 — stacked PRs + Phase 3 complete
+- **Restructured the single `migrate/strawberry` branch into 3 stacked PRs** (one per phase) via cherry-pick: #63 P0 → `deploy-test`, #64 P1 → P0, #65 P2 → P1. P2's tree is byte-identical to the old branch (only log entry ordering differs). Original `migrate/strawberry` left on origin as a backup.
+- **Trap #14 bit us live:** PRs #64/#65 (base = feature branch) got **no CI** until I removed the `branches: [main, deploy-test]` filter from `dev.yml` (committed on P0, cascade-rebased P1/P2). After that all three PRs ran tests and **passed**. (For same-repo PRs the head branch's workflow runs, so the fix had to be on every head branch → cascade.)
+- **Phase 3 (this branch, #66 → P2):** parametrized `client` fixture runs the 7 existing schema-test files against **both** schemas; added parity / corpus-replay / HTTP tests. **87 pass**, ruff/mypy clean.
+- **Follow-ups (Phase 4):** (1) `strawberry.scalar(NewType(...))` emits a DeprecationWarning ("use `StrawberryConfig.scalar_map`") — defer; changing it risks the `JSONString` SDL name/description, and CI ignores warnings. (2) `mangum` "no current event loop" warning on import — benign.
+- **Next:** Phase 4 — deploy/CI/deps hardening (validate Lambda dep packaging without serverless-wsgi; Dependabot vulns; memory watch).
 
 <!-- Append new dated entries above this line as the migration proceeds. -->

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,40 @@
+"""Shared test fixtures.
+
+During the Graphene → Strawberry migration the `client` fixture is **parametrized
+over both schemas**, so every existing schema test runs against the legacy Graphene
+schema *and* the new Strawberry schema. This enforces behavioural parity with the
+test suite we already trust. At cutover, drop the `"legacy"` param (and the legacy
+imports) and the same tests keep guarding the Strawberry schema.
+"""
+
+import pytest
+from graphene.test import Client as GrapheneClient
+
+from nshm_model_graphql_api import schema as legacy_schema
+from nshm_model_graphql_api.strawberry_schema import schema as strawberry_schema
+
+
+class StrawberryClient:
+    """Adapter giving the Strawberry schema the `graphene.test.Client.execute()` shape.
+
+    Returns a dict with `data` (and `errors` only when present), matching how the
+    existing tests read results (`executed["data"]`, `executed["errors"]`).
+    """
+
+    def __init__(self, schema):
+        self._schema = schema
+
+    def execute(self, query, variables=None, **kwargs):
+        result = self._schema.execute_sync(query, variable_values=variables)
+        out = {"data": result.data}
+        if result.errors:
+            out["errors"] = [{"message": err.message} for err in result.errors]
+        return out
+
+
+@pytest.fixture(scope="module", params=["legacy", "strawberry"])
+def client(request):
+    """A GraphQL client over the legacy (Graphene) or new (Strawberry) schema."""
+    if request.param == "legacy":
+        return GrapheneClient(legacy_schema.schema_root)
+    return StrawberryClient(strawberry_schema)

--- a/tests/test_corpus_replay.py
+++ b/tests/test_corpus_replay.py
@@ -1,0 +1,33 @@
+"""Replay the vendored client query corpus against the Strawberry schema.
+
+Catches runtime regressions that SDL parity can't (a query that validates but
+errors at execution). The corpus includes the real weka `LogicTreePageQuery`,
+which exercises nearly the whole schema in one operation.
+"""
+
+import pathlib
+
+import pytest
+from graphql_relay import to_global_id
+
+from nshm_model_graphql_api.strawberry_schema import schema
+
+CORPUS_DIR = pathlib.Path(__file__).parent / "fixtures" / "corpus"
+CORPUS = sorted(CORPUS_DIR.glob("*.graphql"))
+
+# Variables for the queries that need them.
+VARIABLES = {
+    "weka__logic_tree_page.graphql": {"version": "NSHM_v1.0.4"},
+    "seed__node_relay_lookup.graphql": {"id": to_global_id("NshmModel", "NSHM_v1.0.4")},
+}
+
+
+def test_corpus_is_not_empty():
+    assert CORPUS, "no corpus queries found"
+
+
+@pytest.mark.parametrize("path", CORPUS, ids=lambda p: p.name)
+def test_corpus_query_executes(path):
+    result = schema.execute_sync(path.read_text(), variable_values=VARIABLES.get(path.name))
+    assert result.errors is None, f"{path.name}: {result.errors}"
+    assert result.data is not None

--- a/tests/test_schema_gmm_models_as_relay_node.py
+++ b/tests/test_schema_gmm_models_as_relay_node.py
@@ -1,13 +1,5 @@
 import pytest
-from graphene.test import Client
 from graphql_relay import to_global_id
-
-from nshm_model_graphql_api import schema
-
-
-@pytest.fixture(scope="module")
-def client():
-    return Client(schema.schema_root)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_schema_info.py
+++ b/tests/test_schema_info.py
@@ -1,12 +1,4 @@
-import pytest
-from graphene.test import Client
-
-from nshm_model_graphql_api import __version__, schema
-
-
-@pytest.fixture(scope="module")
-def client():
-    return Client(schema.schema_root)
+from nshm_model_graphql_api import __version__
 
 
 def test_get_about(client):

--- a/tests/test_schema_model_gmm_logic_tree.py
+++ b/tests/test_schema_model_gmm_logic_tree.py
@@ -1,16 +1,8 @@
 import json
 
 import pytest
-from graphene.test import Client
-
-from nshm_model_graphql_api import schema
 
 # from graphql_relay import to_global_id
-
-
-@pytest.fixture(scope="module")
-def client():
-    return Client(schema.schema_root)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_schema_model_source_logic_tree.py
+++ b/tests/test_schema_model_source_logic_tree.py
@@ -1,14 +1,6 @@
 import pytest
-from graphene.test import Client
-
-from nshm_model_graphql_api import schema
 
 # from graphql_relay import to_global_id
-
-
-@pytest.fixture(scope="module")
-def client():
-    return Client(schema.schema_root)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_schema_models.py
+++ b/tests/test_schema_models.py
@@ -1,13 +1,5 @@
 import pytest
-from graphene.test import Client
 from graphql_relay import to_global_id
-
-from nshm_model_graphql_api import schema
-
-
-@pytest.fixture(scope="module")
-def client():
-    return Client(schema.schema_root)
 
 
 def test_get_models(client):

--- a/tests/test_schema_models_as_relay_node.py
+++ b/tests/test_schema_models_as_relay_node.py
@@ -1,13 +1,5 @@
 import pytest
-from graphene.test import Client
 from graphql_relay import to_global_id
-
-from nshm_model_graphql_api import schema
-
-
-@pytest.fixture(scope="module")
-def client():
-    return Client(schema.schema_root)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_schema_parity.py
+++ b/tests/test_schema_parity.py
@@ -1,0 +1,29 @@
+"""Migration parity gates.
+
+The Strawberry schema must stay SDL-identical to the Graphene baseline. These
+tests fail loudly if the new schema drifts from the contract (added/removed/
+retyped field, changed nullability, lost description) — order is ignored.
+"""
+
+import pathlib
+
+from graphql import build_schema, print_schema
+from graphql.utilities import lexicographic_sort_schema
+
+from nshm_model_graphql_api import schema as legacy_schema
+from nshm_model_graphql_api.strawberry_schema import schema as strawberry_schema
+
+BASELINE = pathlib.Path(__file__).parent.parent / "schema.legacy.graphql"
+
+
+def _canonical(sdl: str) -> str:
+    """Order-insensitive canonical SDL (sorts types/fields, normalizes formatting)."""
+    return print_schema(lexicographic_sort_schema(build_schema(sdl)))
+
+
+def test_strawberry_sdl_matches_committed_baseline():
+    assert _canonical(BASELINE.read_text()) == _canonical(strawberry_schema.as_str())
+
+
+def test_strawberry_sdl_matches_live_legacy_schema():
+    assert _canonical(str(legacy_schema.schema_root)) == _canonical(strawberry_schema.as_str())

--- a/tests/test_schema_source_models_as_relay_node.py
+++ b/tests/test_schema_source_models_as_relay_node.py
@@ -1,13 +1,5 @@
 import pytest
-from graphene.test import Client
 from graphql_relay import to_global_id
-
-from nshm_model_graphql_api import schema
-
-
-@pytest.fixture(scope="module")
-def client():
-    return Client(schema.schema_root)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_strawberry_http.py
+++ b/tests/test_strawberry_http.py
@@ -1,0 +1,37 @@
+"""HTTP integration tests for the FastAPI app (request → router → schema → response).
+
+Validates the FastAPI/Strawberry wiring end-to-end, which the schema-level tests
+don't exercise. Mangum (the Lambda adapter) wraps this same `app`.
+"""
+
+import pathlib
+
+from fastapi.testclient import TestClient
+
+from nshm_model_graphql_api.app import app
+
+client = TestClient(app)
+
+
+def test_post_query_returns_data():
+    r = client.post("/graphql", json={"query": "{ about version current_model_version }"})
+    assert r.status_code == 200
+    data = r.json()["data"]
+    assert data["version"]
+    assert data["current_model_version"]
+
+
+def test_get_serves_graphiql():
+    r = client.get("/graphql", headers={"accept": "text/html"})
+    assert r.status_code == 200
+    assert "graphiql" in r.text.lower()
+
+
+def test_weka_query_over_http():
+    query = (pathlib.Path(__file__).parent / "fixtures" / "corpus" / "weka__logic_tree_page.graphql").read_text()
+    r = client.post("/graphql", json={"query": query, "variables": {"version": "NSHM_v1.0.4"}})
+    assert r.status_code == 200
+    body = r.json()
+    assert body.get("errors") is None
+    assert body["data"]["get_model"]["version"] == "NSHM_v1.0.4"
+    assert body["data"]["get_model"]["gmm_logic_tree"]["branch_sets"]


### PR DESCRIPTION
**Stacked PR 4 of 4** — Base: \`migrate/strawberry-p2-schema\`.

Phase 3 makes the test suite guard the Strawberry schema:
- \`tests/conftest.py\` — **parametrized \`client\` fixture** (legacy Graphene + Strawberry) with a \`.execute()\` shim. The 7 existing schema-test files now run against **both** schemas (their local fixtures removed). At cutover, drop the \`legacy\` param and the same tests keep guarding Strawberry.
- \`tests/test_schema_parity.py\` — SDL parity gate (vs committed baseline AND vs live legacy schema).
- \`tests/test_corpus_replay.py\` — every vendored corpus query (incl. real weka query) executes on Strawberry with no errors.
- \`tests/test_strawberry_http.py\` — FastAPI \`TestClient\`: query, GraphiQL, weka query over HTTP.

testcontainers not needed (read-only, fully local). Parity + corpus run inside \`pytest\` → already in CI. **87 tests pass** (was 39); ruff/mypy clean.

Next: P4 — deploy/CI/deps hardening.